### PR TITLE
coordinated forks update

### DIFF
--- a/node-runner-cli/Pipfile
+++ b/node-runner-cli/Pipfile
@@ -4,10 +4,10 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-radixdlt_core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true, ref = "1.0-beta.1"}
+core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true, ref = "co-ordinated-forks-david-v3"}
 requests = "==2.26.0"
 PyYAML = "==5.4.1"
 deepmerge = "==0.3.0"
 
 [requires]
-python_version = "3.7.6"
+python_version = "3.10.0"

--- a/node-runner-cli/Pipfile
+++ b/node-runner-cli/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true}
+core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true, ref = "master"}
 requests = "==2.26.0"
 PyYAML = "==5.4.1"
 deepmerge = "==0.3.0"

--- a/node-runner-cli/Pipfile
+++ b/node-runner-cli/Pipfile
@@ -10,4 +10,4 @@ PyYAML = "==5.4.1"
 deepmerge = "==0.3.0"
 
 [requires]
-python_version = "3.10.0"
+python_version = "3.7.6"

--- a/node-runner-cli/Pipfile
+++ b/node-runner-cli/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true, ref = "master"}
+core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true, ref = "1.1.1"}
 requests = "==2.26.0"
 PyYAML = "==5.4.1"
 deepmerge = "==0.3.0"

--- a/node-runner-cli/Pipfile
+++ b/node-runner-cli/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true, ref = "1.1.1"}
+core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true, ref = "v1.1.1"}
 requests = "==2.26.0"
 PyYAML = "==5.4.1"
 deepmerge = "==0.3.0"

--- a/node-runner-cli/Pipfile
+++ b/node-runner-cli/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true, ref = "co-ordinated-forks-david-v3"}
+core_client = {git = "https://github.com/radixdlt/python-core-client", editable = true}
 requests = "==2.26.0"
 PyYAML = "==5.4.1"
 deepmerge = "==0.3.0"

--- a/node-runner-cli/Pipfile.lock
+++ b/node-runner-cli/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "36323963acde9c970ebb417975faa35b1b74ce3c252d0cb799298244c51eaadd"
+            "sha256": "3c69e2d39e5fcc7c2f3c631f1d1b131b653e7d79333c0fbd2d779305d62b38d9"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7.6"
+            "python_version": "3.10.0"
         },
         "sources": [
             {
@@ -25,11 +25,16 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd",
-                "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.10"
+            "version": "==2.0.12"
+        },
+        "core-client": {
+            "editable": true,
+            "git": "https://github.com/radixdlt/python-core-client",
+            "ref": "1933bb4284f5682450eb4c6e006d6d8d1f59b839"
         },
         "deepmerge": {
             "hashes": [
@@ -90,11 +95,6 @@
             "index": "pypi",
             "version": "==5.4.1"
         },
-        "radixdlt-core-client": {
-            "editable": true,
-            "git": "https://github.com/radixdlt/python-core-client",
-            "ref": "c2898218f5b7b48b994e1e6be1c39f0443d3f7f0"
-        },
         "requests": {
             "hashes": [
                 "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
@@ -113,11 +113,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
-                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
+                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.8"
+            "version": "==1.26.9"
         }
     },
     "develop": {}

--- a/node-runner-cli/Pipfile.lock
+++ b/node-runner-cli/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3c69e2d39e5fcc7c2f3c631f1d1b131b653e7d79333c0fbd2d779305d62b38d9"
+            "sha256": "328f6471db7ef9bbd9cc670354604f81e520cf70d7c71347fb302e3d9044870d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,7 +34,7 @@
         "core-client": {
             "editable": true,
             "git": "https://github.com/radixdlt/python-core-client",
-            "ref": "1933bb4284f5682450eb4c6e006d6d8d1f59b839"
+            "ref": "2f8cfea98c3a412a917fe13de0a6fd89e8648fb9"
         },
         "deepmerge": {
             "hashes": [

--- a/node-runner-cli/Pipfile.lock
+++ b/node-runner-cli/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "328f6471db7ef9bbd9cc670354604f81e520cf70d7c71347fb302e3d9044870d"
+            "sha256": "24e0c5abc5bc032fbf17411d1a2f908b7b05ba6e65c7e895abe959f7b80a1c80"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.10.0"
+            "python_version": "3"
         },
         "sources": [
             {

--- a/node-runner-cli/api/Action.py
+++ b/node-runner-cli/api/Action.py
@@ -108,24 +108,8 @@ class Action:
         ]
     
     @staticmethod
-    def vote():
-        return Action.set_validator_metadata("name", "https://www.validator.com")
-        #return Action.set_validator_registeration(True)
-        # return lambda node_identifiers: [
-        #     OperationGroup([
-        #         Operation(
-        #             type="Data",
-        #             entity_identifier=node_identifiers.validator_entity_identifier,
-        #             data=Data(
-        #                 action='CREATE',
-        #                 data_object=ValidatorSystemMetadata(
-        #                     type="ValidatorSystemMetadata",
-        #                     data=""
-        #                 )
-        #             )
-        #         )
-        #     ])
-        # ]
+    def vote():        
+        return Action.set_validator_registeration(True)
     
     @staticmethod
     def cancel_vote():

--- a/node-runner-cli/api/Action.py
+++ b/node-runner-cli/api/Action.py
@@ -13,7 +13,7 @@ from core_client.model.sub_entity_metadata import SubEntityMetadata
 from core_client.model.token_resource_identifier import TokenResourceIdentifier
 from core_client.model.validator_allow_delegation import ValidatorAllowDelegation
 from core_client.model.validator_metadata import ValidatorMetadata
-
+from core_client.model.validator_system_metadata import ValidatorSystemMetadata
 
 class Action:
     @staticmethod
@@ -101,6 +101,44 @@ class Action:
                         data_object=PreparedValidatorOwner(
                             type="PreparedValidatorOwner",
                             owner=EntityIdentifier(address=owner)
+                        )
+                    )
+                )
+            ]),
+        ]
+    
+    @staticmethod
+    def vote():
+        return Action.set_validator_metadata("name", "https://www.validator.com")
+        #return Action.set_validator_registeration(True)
+        # return lambda node_identifiers: [
+        #     OperationGroup([
+        #         Operation(
+        #             type="Data",
+        #             entity_identifier=node_identifiers.validator_entity_identifier,
+        #             data=Data(
+        #                 action='CREATE',
+        #                 data_object=ValidatorSystemMetadata(
+        #                     type="ValidatorSystemMetadata",
+        #                     data=""
+        #                 )
+        #             )
+        #         )
+        #     ])
+        # ]
+    
+    @staticmethod
+    def cancel_vote():
+        return lambda node_identifiers: [
+            OperationGroup([
+                Operation(
+                    type="Data",
+                    entity_identifier=node_identifiers.validator_entity_identifier,
+                    data=Data(
+                        action='CREATE',
+                        data_object=ValidatorSystemMetadata(
+                            type="ValidatorSystemMetadata",
+                            data="0" * 32
                         )
                     )
                 )

--- a/node-runner-cli/api/Action.py
+++ b/node-runner-cli/api/Action.py
@@ -109,7 +109,21 @@ class Action:
     
     @staticmethod
     def vote():        
-        return Action.set_validator_registeration(True)
+        return lambda node_identifiers: [
+            OperationGroup([
+                Operation(
+                    type="Data",
+                    entity_identifier=node_identifiers.validator_entity_identifier,
+                    data=Data(
+                        action='CREATE',
+                        data_object=ValidatorSystemMetadata(
+                            type="ValidatorSystemMetadata",
+                            data=""
+                        )
+                    )
+                )
+            ]),
+        ]
     
     @staticmethod
     def cancel_vote():

--- a/node-runner-cli/api/Api.py
+++ b/node-runner-cli/api/Api.py
@@ -8,8 +8,8 @@ class API:
 
     @staticmethod
     def get_host_info():
-        scheme = os.getenv("API_SCHEME", "https")
-        node_host = os.getenv("NODE_END_POINT", f'{scheme}://localhost')
+        scheme = os.getenv("API_SCHEME", "http")
+        node_host = os.getenv("NODE_END_POINT", f'{scheme}://localhost:3333')
         return node_host
 
     @staticmethod

--- a/node-runner-cli/api/Api.py
+++ b/node-runner-cli/api/Api.py
@@ -8,8 +8,8 @@ class API:
 
     @staticmethod
     def get_host_info():
-        scheme = os.getenv("API_SCHEME", "http")
-        node_host = os.getenv("NODE_END_POINT", f'{scheme}://localhost:3333')
+        scheme = os.getenv("API_SCHEME", "https")
+        node_host = os.getenv("NODE_END_POINT", f'{scheme}://localhost')
         return node_host
 
     @staticmethod

--- a/node-runner-cli/api/CoreApiHelper.py
+++ b/node-runner-cli/api/CoreApiHelper.py
@@ -108,7 +108,7 @@ class CoreApiHelper(API):
                 )
                 return self.handle_response(response, print_response)
             except ApiException as e:
-                Helpers.handleApiException(e)                
+                Helpers.handleApiException(e)
 
     def entity(self, entity_identifier, print_response=False):
         with core_api.ApiClient(self.system_config) as api_client:

--- a/node-runner-cli/api/CoreApiHelper.py
+++ b/node-runner-cli/api/CoreApiHelper.py
@@ -26,7 +26,7 @@ from core_client.model.validator_metadata import ValidatorMetadata
 import core_client as core_api
 from api.Api import API
 from api.ValidatorConfig import ValidatorConfig
-from utils.utils import bcolors, Helpers, AttributeDict
+from utils.utils import bcolors, Helpers
 
 
 class CoreApiHelper(API):
@@ -108,17 +108,7 @@ class CoreApiHelper(API):
                 )
                 return self.handle_response(response, print_response)
             except ApiException as e:
-                Helpers.handleApiException(e)
-                
-    def validator_info(self, print_response=False):
-        own_entity_identifier = key_list().public_keys[0].identifiers.validator_entity_identifier
-        entity_response = entity(entity_identifier, False)
-        # first, we 'serialize' the response to raw json
-        json_response = str(response).replace("'", "\"").replace("True", "true").replace("False", "false")
-        # we then use this json to create simple model 'ValidatorInfo', which does not contain any validation (or bugs)
-        validator_info = ValidatorInfo.from_entity_response_json_string(dict_response)
-        print(validator_info)
-        return validator_info
+                Helpers.handleApiException(e)                
 
     def entity(self, entity_identifier, print_response=False):
         with core_api.ApiClient(self.system_config) as api_client:
@@ -129,8 +119,8 @@ class CoreApiHelper(API):
                     network_identifier=self.network_configuration().network_identifier,
                     entity_identifier=entity_identifier
                 )
-                Helpers.print_request_body(entityRequest, "/entity")                
-                response: EntityResponse = api.entity_post(entityRequest)                
+                Helpers.print_request_body(entityRequest, "/entity")
+                response: EntityResponse = api.entity_post(entityRequest)
                 return self.handle_response(response, print_response)
             except ApiException as e:
                 Helpers.handleApiException(e)

--- a/node-runner-cli/api/DefaultApiHelper.py
+++ b/node-runner-cli/api/DefaultApiHelper.py
@@ -58,7 +58,7 @@ class DefaultApiHelper(API):
         Helpers.print_coloured_line("Checking status of the node\n", bcolors.BOLD)
         health = self.health()
 
-        if health["network_status"] != "UP":
+        if health["status"] != "UP":
             Helpers.print_coloured_line(
                 f"Node status is {health['status']} Rerun the command once node is completely synced",
                 bcolors.WARNING)

--- a/node-runner-cli/api/DefaultApiHelper.py
+++ b/node-runner-cli/api/DefaultApiHelper.py
@@ -58,11 +58,12 @@ class DefaultApiHelper(API):
         Helpers.print_coloured_line("Checking status of the node\n", bcolors.BOLD)
         health = self.health()
 
-        if health["status"] != "UP":
+        if health["network_status"] != "UP":
             Helpers.print_coloured_line(
                 f"Node status is {health['status']} Rerun the command once node is completely synced",
                 bcolors.WARNING)
             proceed = input(print("Do you want to continue [Y/n]?"))
             if not Helpers.check_Yes(proceed):
                 sys.exit()
+        return health    
 

--- a/node-runner-cli/api/ValidatorConfig.py
+++ b/node-runner-cli/api/ValidatorConfig.py
@@ -117,8 +117,8 @@ class ValidatorConfig:
     @staticmethod
     def vote(actions: List, health, engine_configuration):
         print("--------Vote--------\n")
-        latest_fork_name = print_vote_and_fork_info(health, engine_configuration)        
-        response = input(f"{bcolors.BOLD}\nDo you want to cast a vote for fork '{latest_fork_name}' [y/n]? " +
+        newest_fork_name = print_vote_and_fork_info(health, engine_configuration)        
+        response = input(f"{bcolors.BOLD}\nDo you want to cast a vote for fork '{newest_fork_name}' [y/n]? " +
                          f"Pressing Enter does not cast a vote: {bcolors.ENDC}").strip()
         if response.lower() == 'y':
             actions.append(Action.vote())

--- a/node-runner-cli/api/ValidatorConfig.py
+++ b/node-runner-cli/api/ValidatorConfig.py
@@ -115,19 +115,19 @@ class ValidatorConfig:
         return actions
 
     @staticmethod
-    def vote(actions: List, validator_info: EntityResponse, health, engine_configuration):
-        print("-------- Vote -----\n")
+    def vote(actions: List, health, engine_configuration):
+        print("--------Vote--------\n")
         latest_fork_name = print_vote_and_fork_info(health, engine_configuration)        
         response = input(f"{bcolors.BOLD}\nDo you want to cast a vote for fork '{latest_fork_name}' [y/n]? " +
-                         f"Presssing Enter does not cast a vote: {bcolors.ENDC}").strip()
+                         f"Pressing Enter does not cast a vote: {bcolors.ENDC}").strip()
         if response.lower() == 'y':
             actions.append(Action.vote())
         return actions
     
     @staticmethod
-    def cancel_vote(actions: List, validator_info: EntityResponse):
+    def cancel_vote(actions: List):
         response = input(f"{bcolors.BOLD}\nDo you want to cancel your vote [y/n]? " +
-                         f"Presssing Enter does not cancel your vote: {bcolors.ENDC}").strip()
+                         f"Pressing Enter does not cancel your vote: {bcolors.ENDC}").strip()
         if response.lower().strip() == 'y':
             actions.append(Action.cancel_vote())
         return actions

--- a/node-runner-cli/api/ValidatorConfig.py
+++ b/node-runner-cli/api/ValidatorConfig.py
@@ -125,8 +125,7 @@ class ValidatorConfig:
         return actions
     
     @staticmethod
-    def cancel_vote(actions: List, validator_info: EntityResponse, health, engine_configuration):
-        #latest_fork_name = print_vote_and_fork_info(health, engine_configuration)
+    def cancel_vote(actions: List, validator_info: EntityResponse):
         response = input(f"{bcolors.BOLD}\nDo you want to cancel your vote [y/n]? " +
                          f"Presssing Enter does not cancel your vote: {bcolors.ENDC}").strip()
         if response.lower().strip() == 'y':

--- a/node-runner-cli/api/ValidatorConfig.py
+++ b/node-runner-cli/api/ValidatorConfig.py
@@ -128,7 +128,7 @@ class ValidatorConfig:
     def cancel_vote(actions: List, validator_info: EntityResponse, health, engine_configuration):
         #latest_fork_name = print_vote_and_fork_info(health, engine_configuration)
         response = input(f"{bcolors.BOLD}\nDo you want to cancel your vote [y/n]? " +
-                         f"Presssing Enter does not cancel your vote. {bcolors.ENDC}").strip()
+                         f"Presssing Enter does not cancel your vote: {bcolors.ENDC}").strip()
         if response.lower().strip() == 'y':
             actions.append(Action.cancel_vote())
         return actions

--- a/node-runner-cli/api/ValidatorConfig.py
+++ b/node-runner-cli/api/ValidatorConfig.py
@@ -3,17 +3,18 @@ import sys
 from typing import List
 from core_client.model.entity_response import EntityResponse
 from api.Action import Action
-from utils.utils import bcolors, Helpers, print_vote_and_fork_info
+from utils.utils import bcolors, Helpers, check_for_candidate_forks, print_vote_and_fork_info
 
 
 class ValidatorConfig:
     @staticmethod
-    def registeration(actions: List, validator_info: EntityResponse):
+    def registration(actions: List, validator_info: EntityResponse, health):
         value_to_set = None
         print("\n--------Registration-----\n")
         registration = [x for x in validator_info.data_objects if x.type == 'PreparedValidatorRegistered']
         Helpers.print_coloured_line(f"Current registration status: {registration[0].registered}",
                                     bcolors.OKBLUE)
+        check_for_candidate_forks(health)
         ask_registration = input(
             Helpers.print_coloured_line(
                 "\nEnter the new registration setting [true/false].Press enter if no change required ",
@@ -27,11 +28,12 @@ class ValidatorConfig:
         return actions
 
     @staticmethod
-    def validator_metadata(actions: List, validator_info: EntityResponse):
+    def validator_metadata(actions: List, validator_info: EntityResponse, health):
         print("\n--------Update validator meta info-----\n")
         validatorMetadata = [x for x in validator_info.data_objects if x.type == 'ValidatorMetadata']
         Helpers.print_coloured_line(f"Current name: {validatorMetadata[0]['name']}", bcolors.OKBLUE)
         Helpers.print_coloured_line(f"Current url: {validatorMetadata[0]['url']}", bcolors.OKBLUE)
+        check_for_candidate_forks(health)
         ask_add_or_change_info = input("\nDo you want add/change the validator name and info url [Y/n]?")
         if Helpers.check_Yes(ask_add_or_change_info):
             validator_name = input(

--- a/node-runner-cli/api/ValidatorConfig.py
+++ b/node-runner-cli/api/ValidatorConfig.py
@@ -3,7 +3,7 @@ import sys
 from typing import List
 from core_client.model.entity_response import EntityResponse
 from api.Action import Action
-from utils.utils import bcolors, Helpers
+from utils.utils import bcolors, Helpers, print_vote_and_fork_info
 
 
 class ValidatorConfig:
@@ -20,7 +20,7 @@ class ValidatorConfig:
                 bcolors.BOLD, return_string=True))
         if ask_registration.lower() == "true" or ask_registration.lower() == "false":
             value_to_set = json.loads(ask_registration.lower())
-            actions.append(Action().set_validator_registeration(value_to_set))
+            actions.append(Action.set_validator_registeration(value_to_set))
             return actions
         else:
             Helpers.print_coloured_line("There are no changes to apply or user input is wrong", bcolors.WARNING)
@@ -40,7 +40,7 @@ class ValidatorConfig:
             validator_url = input(
                 Helpers.print_coloured_line(f"Enter Info URL of your validator to be updated:", bcolors.OKBLUE,
                                             return_string=True))
-            actions.append(Action().set_validator_metadata(validator_name, validator_url))
+            actions.append(Action.set_validator_metadata(validator_name, validator_url))
             return actions
         return actions
 
@@ -57,7 +57,7 @@ class ValidatorConfig:
         ask_validator_fee_setup = input("Do you want to setup or update validator fees [Y/n]?:")
         if Helpers.check_Yes(ask_validator_fee_setup):
             validatorFee = int(Helpers.check_validatorFee_input() * 100)
-            actions.append(Action().set_validator_fee(validatorFee))
+            actions.append(Action.set_validator_fee(validatorFee))
             return actions
         return actions
 
@@ -78,7 +78,7 @@ class ValidatorConfig:
                 bcolors.BOLD, return_string=True))
         if allow_delegation.lower() == "true":
             if not bool(current_value):
-                actions.append(Action().set_validator_allow_delegation(json.loads(allow_delegation.lower())))
+                actions.append(Action.set_validator_allow_delegation(json.loads(allow_delegation.lower())))
                 return actions
             else:
                 Helpers.print_coloured_line(
@@ -86,7 +86,7 @@ class ValidatorConfig:
                     f". So not updating this action", bcolors.WARNING)
         elif allow_delegation.lower() == "false":
             if bool(current_value):
-                actions.append(Action().set_validator_allow_delegation(json.loads(allow_delegation.lower())))
+                actions.append(Action.set_validator_allow_delegation(json.loads(allow_delegation.lower())))
                 return actions
             else:
                 Helpers.print_coloured_line(
@@ -108,12 +108,31 @@ class ValidatorConfig:
         owner_id = input("\nEnter the new owner id or press Enter not to change:").strip()
         if owner_id != "":
             if owner_id != current_value:
-                actions.append(Action().set_validator_owner(owner_id))
+                actions.append(Action.set_validator_owner(owner_id))
                 return actions
             Helpers.print_coloured_line("Owner entered is same . So action will not be applied", bcolors.WARNING)
 
         return actions
 
+    @staticmethod
+    def vote(actions: List, validator_info: EntityResponse, health, engine_configuration):
+        print("-------- Vote -----\n")
+        latest_fork_name = print_vote_and_fork_info(health, engine_configuration)        
+        response = input(f"{bcolors.BOLD}\nDo you want to cast a vote for fork '{latest_fork_name}' [y/n]? " +
+                         f"Presssing Enter does not cast a vote: {bcolors.ENDC}").strip()
+        if response.lower() == 'y':
+            actions.append(Action.vote())
+        return actions
+    
+    @staticmethod
+    def cancel_vote(actions: List, validator_info: EntityResponse, health, engine_configuration):
+        #latest_fork_name = print_vote_and_fork_info(health, engine_configuration)
+        response = input(f"{bcolors.BOLD}\nDo you want to cancel your vote [y/n]? " +
+                         f"Presssing Enter does not cancel your vote. {bcolors.ENDC}").strip()
+        if response.lower().strip() == 'y':
+            actions.append(Action.cancel_vote())
+        return actions
+        
     @staticmethod
     def build_operations(actions, key_list, ask_user=False):
         operation_groups = []

--- a/node-runner-cli/radixnode.py
+++ b/node-runner-cli/radixnode.py
@@ -14,7 +14,6 @@ from core_client.model.key_list_response import KeyListResponse
 from core_client.model.key_sign_response import KeySignResponse
 from core_client.model.sub_entity import SubEntity
 from core_client.model.sub_entity_metadata import SubEntityMetadata
-
 from api.Api import API
 from api.CoreApiHelper import CoreApiHelper
 from api.DefaultApiHelper import DefaultApiHelper
@@ -25,7 +24,7 @@ from monitoring import Monitoring
 from setup import Base, Docker, SystemD
 from utils.utils import Helpers
 from utils.utils import run_shell_command
-from version import __version__
+#from version import __version__
 
 urllib3.disable_warnings()
 
@@ -228,7 +227,7 @@ def authcommand(args=[], parent=auth_parser):
 
 
 def cli_version():
-    return __version__
+    return "1.1.1"
 
 
 def print_cli_version():
@@ -508,10 +507,12 @@ def update_validator_config(args):
     system_config = system_api.Configuration(node_host, verify_ssl=False)
 
     defaultApiHelper = DefaultApiHelper(verify_ssl=False)
-    defaultApiHelper.check_health()
+    health = defaultApiHelper.check_health()
 
     core_api_helper = CoreApiHelper(verify_ssl=False)
+    engine_configuration = core_api_helper.engine_configuration()
     key_list_response: KeyListResponse = core_api_helper.key_list()
+    
     validator_info: EntityResponse = core_api_helper.entity(
         key_list_response.public_keys[0].identifiers.validator_entity_identifier)
 
@@ -521,6 +522,8 @@ def update_validator_config(args):
     actions = ValidatorConfig.add_validation_fee(actions, validator_info)
     actions = ValidatorConfig.setup_update_delegation(actions, validator_info)
     actions = ValidatorConfig.add_change_ownerid(actions, validator_info)
+    actions = ValidatorConfig.vote(actions, validator_info, health, engine_configuration)
+    actions = ValidatorConfig.cancel_vote(actions, validator_info, health, engine_configuration)
     build_response: ConstructionBuildResponse = core_api_helper.construction_build(actions, ask_user=True)
     signed_transaction: KeySignResponse = core_api_helper.key_sign(build_response.unsigned_transaction)
     submitted_transaction: ConstructionSubmitResponse = core_api_helper.construction_submit(

--- a/node-runner-cli/radixnode.py
+++ b/node-runner-cli/radixnode.py
@@ -24,7 +24,7 @@ from monitoring import Monitoring
 from setup import Base, Docker, SystemD
 from utils.utils import Helpers
 from utils.utils import run_shell_command
-#from version import __version__
+from version import __version__
 
 urllib3.disable_warnings()
 
@@ -227,7 +227,7 @@ def authcommand(args=[], parent=auth_parser):
 
 
 def cli_version():
-    return "1.1.1"
+    return __version__
 
 
 def print_cli_version():

--- a/node-runner-cli/radixnode.py
+++ b/node-runner-cli/radixnode.py
@@ -518,8 +518,8 @@ def update_validator_config(args):
         key_list_response.public_keys[0].identifiers.validator_entity_identifier)
 
     actions = []
-    actions = ValidatorConfig.registeration(actions, validator_info)
-    actions = ValidatorConfig.validator_metadata(actions, validator_info)
+    actions = ValidatorConfig.registration(actions, validator_info, health)
+    actions = ValidatorConfig.validator_metadata(actions, validator_info, health)
     actions = ValidatorConfig.add_validation_fee(actions, validator_info)
     actions = ValidatorConfig.setup_update_delegation(actions, validator_info)
     actions = ValidatorConfig.add_change_ownerid(actions, validator_info)

--- a/node-runner-cli/radixnode.py
+++ b/node-runner-cli/radixnode.py
@@ -24,7 +24,7 @@ from monitoring import Monitoring
 from setup import Base, Docker, SystemD
 from utils.utils import Helpers
 from utils.utils import run_shell_command
-from version import __version__
+#from version import __version__
 
 urllib3.disable_warnings()
 
@@ -227,7 +227,8 @@ def authcommand(args=[], parent=auth_parser):
 
 
 def cli_version():
-    return __version__
+    #return __version__
+    return "1.1.1"
 
 
 def print_cli_version():
@@ -522,8 +523,8 @@ def update_validator_config(args):
     actions = ValidatorConfig.add_validation_fee(actions, validator_info)
     actions = ValidatorConfig.setup_update_delegation(actions, validator_info)
     actions = ValidatorConfig.add_change_ownerid(actions, validator_info)
-    actions = ValidatorConfig.vote(actions, validator_info, health, engine_configuration)
-    actions = ValidatorConfig.cancel_vote(actions, validator_info, health, engine_configuration)
+    actions = ValidatorConfig.vote(actions, health, engine_configuration)
+    actions = ValidatorConfig.cancel_vote(actions)
     build_response: ConstructionBuildResponse = core_api_helper.construction_build(actions, ask_user=True)
     signed_transaction: KeySignResponse = core_api_helper.key_sign(build_response.unsigned_transaction)
     submitted_transaction: ConstructionSubmitResponse = core_api_helper.construction_submit(

--- a/node-runner-cli/radixnode.py
+++ b/node-runner-cli/radixnode.py
@@ -24,7 +24,7 @@ from monitoring import Monitoring
 from setup import Base, Docker, SystemD
 from utils.utils import Helpers
 from utils.utils import run_shell_command
-#from version import __version__
+from version import __version__
 
 urllib3.disable_warnings()
 
@@ -227,8 +227,7 @@ def authcommand(args=[], parent=auth_parser):
 
 
 def cli_version():
-    #return __version__
-    return "1.1.1"
+    return __version__
 
 
 def print_cli_version():

--- a/node-runner-cli/requirements.txt
+++ b/node-runner-cli/requirements.txt
@@ -6,13 +6,13 @@
 #
 
 -i https://pypi.org/simple
--e git+https://github.com/radixdlt/python-core-client@c2898218f5b7b48b994e1e6be1c39f0443d3f7f0#egg=radixdlt-core-client
-certifi==2021.10.8
-charset-normalizer==2.0.10; python_version >= '3'
+-e git+https://github.com/radixdlt/python-core-client@8e115c0cbc619f68d4dbcbc87cfb599e886823b1#egg=core-client
+charset-normalizer==2.0.12; python_version >= '3'
 deepmerge==0.3.0
 idna==3.3; python_version >= '3'
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyyaml==5.4.1
 requests==2.26.0
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-urllib3==1.26.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
+urllib3==1.26.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
+PS C:\Users\thech\work\node-runner\node-runner-cli> python .\radixnode.py api core update-validator-config

--- a/node-runner-cli/requirements.txt
+++ b/node-runner-cli/requirements.txt
@@ -6,7 +6,8 @@
 #
 
 -i https://pypi.org/simple
--e git+https://github.com/radixdlt/python-core-client@8e115c0cbc619f68d4dbcbc87cfb599e886823b1#egg=core-client
+-e git+https://github.com/radixdlt/python-core-client@2f8cfea98c3a412a917fe13de0a6fd89e8648fb9#egg=core-client
+certifi==2021.10.8
 charset-normalizer==2.0.12; python_version >= '3'
 deepmerge==0.3.0
 idna==3.3; python_version >= '3'
@@ -15,4 +16,3 @@ pyyaml==5.4.1
 requests==2.26.0
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 urllib3==1.26.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
-PS C:\Users\thech\work\node-runner\node-runner-cli> python .\radixnode.py api core update-validator-config

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -33,6 +33,23 @@ def run_shell_command(cmd, env=None, shell=False, fail_on_error=True, quite=Fals
         sys.exit()
     return result
 
+def print_vote_and_fork_info(health, engine_configuration):
+    vote_status = health['fork_vote_status']
+    print(f"Vote status : {vote_status}")
+    if vote_status != 'VOTE_REQUIRED':
+        print(f"{bcolors.WARNING}No vote is required at the moment{bcolors.ENDC}")    
+    latest_fork = engine_configuration['forks'][-1] 
+    latest_fork_name = latest_fork['name']
+    is_candidate = latest_fork['is_candidate']
+    if health['current_fork_name'] == latest_fork_name:        
+        print(f"\nCurrent fork : {latest_fork_name}, is candidate: {is_candidate}")    
+        print(f"{bcolors.WARNING}The validator is on the latest fork{bcolors.ENDC}")
+    else:
+        print(f"\nLatest fork : {latest_fork_name}, is candidate: {is_candidate}")    
+    
+    if not is_candidate:
+        print(f"{bcolors.WARNING}Fork '{latest_fork_name}' is not a candidate fork, voting will have no effect{bcolors.ENDC}")    
+    return latest_fork_name
 
 class Helpers:
     @staticmethod
@@ -73,14 +90,15 @@ class Helpers:
         nginx_password = f'NGINX_{usertype.upper()}_PASSWORD'
         nginx_username = f'NGINX_{default_username.upper()}_USERNAME'
         if os.environ.get('%s' % nginx_password) is None:
-            print(f"""
-            ------
-            NGINX_{usertype.upper()}_PASSWORD is missing !
-            Setup NGINX_{usertype.upper()}_PASSWORD environment variable using below command . Replace the string 'nginx_password_of_your_choice' with your password
+            pass
+            # print(f"""
+            # ------
+            # NGINX_{usertype.upper()}_PASSWORD is missing !
+            # Setup NGINX_{usertype.upper()}_PASSWORD environment variable using below command . Replace the string 'nginx_password_of_your_choice' with your password
 
-            echo 'export NGINX_{usertype.upper()}_PASSWORD="nginx_password_of_your_choice"' >> ~/.bashrc
-            """)
-            sys.exit()
+            # echo 'export NGINX_{usertype.upper()}_PASSWORD="nginx_password_of_your_choice"' >> ~/.bashrc
+            # """)
+            # sys.exit()
         else:
             # if os.getenv(nginx_username) is None:
             #     print (f"Using default name of usertype {usertype} as {default_username}")
@@ -188,11 +206,11 @@ class Helpers:
     @staticmethod
     def get_basic_auth_header(user):
         import base64
-        data = f"{user['name']}:{user['password']}"
-        encodedBytes = base64.b64encode(data.encode("utf-8"))
-        encodedStr = str(encodedBytes, "utf-8")
+        # data = f"{user['name']}:{user['password']}"
+        # encodedBytes = base64.b64encode(data.encode("utf-8"))
+        # encodedStr = str(encodedBytes, "utf-8")
         headers = {
-            'Authorization': f'Basic {encodedStr}'}
+             'Authorization': f'Basic a'}
         return headers
 
     @staticmethod
@@ -223,3 +241,8 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
+
+class AttributeDict(dict):
+    __slots__ = () 
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -92,15 +92,14 @@ class Helpers:
         nginx_password = f'NGINX_{usertype.upper()}_PASSWORD'
         nginx_username = f'NGINX_{default_username.upper()}_USERNAME'
         if os.environ.get('%s' % nginx_password) is None:
-            pass
-            # print(f"""
-            # ------
-            # NGINX_{usertype.upper()}_PASSWORD is missing !
-            # Setup NGINX_{usertype.upper()}_PASSWORD environment variable using below command . Replace the string 'nginx_password_of_your_choice' with your password
+            print(f"""
+            ------
+            NGINX_{usertype.upper()}_PASSWORD is missing !
+            Setup NGINX_{usertype.upper()}_PASSWORD environment variable using below command . Replace the string 'nginx_password_of_your_choice' with your password
 
-            # echo 'export NGINX_{usertype.upper()}_PASSWORD="nginx_password_of_your_choice"' >> ~/.bashrc
-            # """)
-            # sys.exit()
+            echo 'export NGINX_{usertype.upper()}_PASSWORD="nginx_password_of_your_choice"' >> ~/.bashrc
+            """)
+            sys.exit()
         else:
             # if os.getenv(nginx_username) is None:
             #     print (f"Using default name of usertype {usertype} as {default_username}")

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -211,7 +211,7 @@ class Helpers:
         encodedBytes = base64.b64encode(data.encode("utf-8"))
         encodedStr = str(encodedBytes, "utf-8")
         headers = {
-             'Authorization': f'Basic {encodedStr}'}
+            'Authorization': f'Basic {encodedStr}'}
         return headers
 
     @staticmethod
@@ -242,3 +242,4 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
+    

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -40,18 +40,18 @@ def print_vote_and_fork_info(health, engine_configuration):
         print(f"{bcolors.WARNING}Your vote is required{bcolors.ENDC}")    
     else:
         print(f"{bcolors.WARNING}No vote is required at the moment{bcolors.ENDC}")    
-    latest_fork = engine_configuration['forks'][-1] 
-    latest_fork_name = latest_fork['name']
-    is_candidate = latest_fork['is_candidate']
-    if health['current_fork_name'] == latest_fork_name:        
-        print(f"\nCurrent fork: {latest_fork_name}, is candidate: {is_candidate}")    
-        print(f"{bcolors.WARNING}The validator is on the latest fork{bcolors.ENDC}")
+    newest_fork = engine_configuration['forks'][-1] 
+    newest_fork_name = newest_fork['name']
+    is_candidate = newest_fork['is_candidate']
+    if health['current_fork_name'] == newest_fork_name:        
+        print(f"\nCurrent fork: {newest_fork_name}, is candidate: {is_candidate}")    
+        print(f"{bcolors.WARNING}The validator is currently running its newest fork{bcolors.ENDC}")
     else:
-        print(f"\nLatest fork: {latest_fork_name}, is candidate: {is_candidate}")    
+        print(f"\nLatest fork: {newest_fork_name}, is candidate: {is_candidate}")    
     
     if not is_candidate:
-        print(f"{bcolors.WARNING}Fork '{latest_fork_name}' is not a candidate fork, voting will have no effect{bcolors.ENDC}")    
-    return latest_fork_name
+        print(f"{bcolors.WARNING}Fork '{newest_fork_name}' is not a candidate fork, voting will have no effect{bcolors.ENDC}")    
+    return newest_fork_name
 
 class Helpers:
     @staticmethod

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -207,11 +207,11 @@ class Helpers:
     @staticmethod
     def get_basic_auth_header(user):
         import base64
-        # data = f"{user['name']}:{user['password']}"
-        # encodedBytes = base64.b64encode(data.encode("utf-8"))
-        # encodedStr = str(encodedBytes, "utf-8")
+        data = f"{user['name']}:{user['password']}"
+        encodedBytes = base64.b64encode(data.encode("utf-8"))
+        encodedStr = str(encodedBytes, "utf-8")
         headers = {
-             'Authorization': f'Basic a'}
+             'Authorization': f'Basic {encodedStr}'}
         return headers
 
     @staticmethod
@@ -242,8 +242,3 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
-
-class AttributeDict(dict):
-    __slots__ = () 
-    __getattr__ = dict.__getitem__
-    __setattr__ = dict.__setitem__

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -242,4 +242,5 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
+
     

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -33,21 +33,25 @@ def run_shell_command(cmd, env=None, shell=False, fail_on_error=True, quite=Fals
         sys.exit()
     return result
 
+def check_for_candidate_forks(health):
+    if health['fork_vote_status'] == 'VOTE_REQUIRED':
+        print(f"\n{bcolors.WARNING}The newest fork is a candidate one. Submitting this action will trigger a vote{bcolors.ENDC}")
+
 def print_vote_and_fork_info(health, engine_configuration):
     vote_status = health['fork_vote_status']
     print(f"Vote status: {vote_status}")
     if vote_status == 'VOTE_REQUIRED':
-        print(f"{bcolors.WARNING}Your vote is required{bcolors.ENDC}")    
+        print(f"{bcolors.WARNING}Your vote is required{bcolors.ENDC}")
     else:
         print(f"{bcolors.WARNING}No vote is required at the moment{bcolors.ENDC}")    
     newest_fork = engine_configuration['forks'][-1] 
     newest_fork_name = newest_fork['name']
     is_candidate = newest_fork['is_candidate']
-    if health['current_fork_name'] == newest_fork_name:        
-        print(f"\nCurrent fork: {newest_fork_name}, is candidate: {is_candidate}")    
+    print(f"\nThe network is currently running fork {bcolors.BOLD}{newest_fork_name}{bcolors.ENDC}") 
+    if health['current_fork_name'] == newest_fork_name:
         print(f"{bcolors.WARNING}The validator is currently running its newest fork{bcolors.ENDC}")
     else:
-        print(f"\nLatest fork: {newest_fork_name}, is candidate: {is_candidate}")    
+        print(f"The validator is running fork {bcolors.BOLD}{health['current_fork_name']}{bcolors.ENDC}")
     
     if not is_candidate:
         print(f"{bcolors.WARNING}Fork '{newest_fork_name}' is not a candidate fork, voting will have no effect{bcolors.ENDC}")    

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -242,5 +242,4 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
-
     

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -35,7 +35,7 @@ def run_shell_command(cmd, env=None, shell=False, fail_on_error=True, quite=Fals
 
 def print_vote_and_fork_info(health, engine_configuration):
     vote_status = health['fork_vote_status']
-    print(f"Vote status : {vote_status}")
+    print(f"Vote status: {vote_status}")
     if vote_status == 'VOTE_REQUIRED':
         print(f"{bcolors.WARNING}Your vote is required{bcolors.ENDC}")    
     else:
@@ -44,10 +44,10 @@ def print_vote_and_fork_info(health, engine_configuration):
     latest_fork_name = latest_fork['name']
     is_candidate = latest_fork['is_candidate']
     if health['current_fork_name'] == latest_fork_name:        
-        print(f"\nCurrent fork : {latest_fork_name}, is candidate: {is_candidate}")    
+        print(f"\nCurrent fork: {latest_fork_name}, is candidate: {is_candidate}")    
         print(f"{bcolors.WARNING}The validator is on the latest fork{bcolors.ENDC}")
     else:
-        print(f"\nLatest fork : {latest_fork_name}, is candidate: {is_candidate}")    
+        print(f"\nLatest fork: {latest_fork_name}, is candidate: {is_candidate}")    
     
     if not is_candidate:
         print(f"{bcolors.WARNING}Fork '{latest_fork_name}' is not a candidate fork, voting will have no effect{bcolors.ENDC}")    

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -36,7 +36,9 @@ def run_shell_command(cmd, env=None, shell=False, fail_on_error=True, quite=Fals
 def print_vote_and_fork_info(health, engine_configuration):
     vote_status = health['fork_vote_status']
     print(f"Vote status : {vote_status}")
-    if vote_status != 'VOTE_REQUIRED':
+    if vote_status == 'VOTE_REQUIRED':
+        print(f"{bcolors.WARNING}Your vote is required{bcolors.ENDC}")    
+    else:
         print(f"{bcolors.WARNING}No vote is required at the moment{bcolors.ENDC}")    
     latest_fork = engine_configuration['forks'][-1] 
     latest_fork_name = latest_fork['name']

--- a/node-runner-cli/utils/utils.py
+++ b/node-runner-cli/utils/utils.py
@@ -35,7 +35,8 @@ def run_shell_command(cmd, env=None, shell=False, fail_on_error=True, quite=Fals
 
 def check_for_candidate_forks(health):
     if health['fork_vote_status'] == 'VOTE_REQUIRED':
-        print(f"\n{bcolors.WARNING}The newest fork is a candidate one. Submitting this action will trigger a vote{bcolors.ENDC}")
+        print(f"\n{bcolors.WARNING}The newest fork is a candidate one. Submitting this action will also submit a vote for fork " +
+              f"{bcolors.BOLD}{health['current_fork_name']}{bcolors.ENDC}")
 
 def print_vote_and_fork_info(health, engine_configuration):
     vote_status = health['fork_vote_status']


### PR DESCRIPTION
Added two cli commands:
1. Vote
2. Cancel your vote

[They are part of ValidatorConfig.py](https://github.com/radixdlt/node-runner/blob/37280e8098b0c7c119375e015aff197fe6f0e88e/node-runner-cli/api/ValidatorConfig.py#L118). Run them with:
```
python radixnode.py api core update-validator-config
```
The CLI text when a vote is required:
![vote_required](https://user-images.githubusercontent.com/3509654/162735138-b8750ac5-6eca-44bc-8f6d-9610bba8b387.PNG)

After a vote has been cast:
![no_vote_required](https://user-images.githubusercontent.com/3509654/162735537-17822aaf-112f-40f2-88a4-3142009a2589.PNG)

When there is no candidate branch:
![nothing_needed](https://user-images.githubusercontent.com/3509654/162735222-bf29a5d3-b4f0-4e33-b086-04319f112c29.PNG)

Users are warned if they register:
![warning](https://user-images.githubusercontent.com/3509654/162737040-9fe1e4e4-1046-4256-be9f-5b1e58c7cbe0.PNG)

And if they want to update metadata:
![warning2](https://user-images.githubusercontent.com/3509654/162737047-cb4777a9-0123-4a8b-a30e-523ca0e4a6ff.PNG)

Voting (and coordinated forks in general) is explained here: [Design Doc](https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/2606071814/Coordinated+forks+design#How-does-a-validator-send-their-vote?).

I have tested the above in a local network running the `feature/NT-242-NT-247-NT-248-fork-voting` branch.

