### PR TITLE
node-runner: add support for 22.04 + build instructions

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -95,3 +95,32 @@ optional arguments:
 
 ----
 
+== Build instructions
+
+Install Docker Engine:
+
+https://docs.docker.com/engine/install/ubuntu/
+
+Post docker install, add current user to docker group:
+
+https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user
+
+Ubuntu:
+[source, bash]
+----
+sudo apt-get -y install build-essential python3 python3-env
+
+python3 -m pip install pipenv
+
+# For Ubuntu Jammy ( 22.04 ):
+make output-ubuntu-jammy
+chmod +x out/ubuntu/jammy/radixnode
+sudo cp out/ubuntu/jammy/radixnode /usr/local/bin/radixnode
+
+
+# For Ubuntu Focal ( 20.04 ):
+make output-ubuntu-jammy
+chmod +x out/ubuntu/focal/radixnode
+sudo cp out/ubuntu/focal/radixnode /usr/local/bin/radixnode
+
+----

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -95,7 +95,7 @@ optional arguments:
 
 ----
 
-== Build instructions
+== Build and install instructions
 
 Install Docker Engine:
 

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -119,7 +119,7 @@ sudo cp out/ubuntu/jammy/radixnode /usr/local/bin/radixnode
 
 
 # For Ubuntu Focal ( 20.04 ):
-make output-ubuntu-jammy
+make output-ubuntu-focal
 chmod +x out/ubuntu/focal/radixnode
 sudo cp out/ubuntu/focal/radixnode /usr/local/bin/radixnode
 

--- a/node-runner-cli/Dockerfile.ubuntujammy
+++ b/node-runner-cli/Dockerfile.ubuntujammy
@@ -1,0 +1,43 @@
+FROM ubuntu:22.04 as BUILD
+MAINTAINER radixdlt <devops@radixdlt.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PYTHON_VERSION 3.10
+
+CMD /bin/bash
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends make build-essential libssl-dev zlib1g-dev \
+     libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+     libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev ca-certificates git  > /dev/null
+
+
+
+ENV PYENV_ROOT /root/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+# Install pyenv
+RUN set -ex \
+    && curl https://pyenv.run | bash \
+    && pyenv update
+
+
+RUN CONFIGURE_OPTS=--enable-shared pyenv install 3.10
+
+
+
+RUN pyenv virtualenv 3.10 nodecli
+RUN pyenv local nodecli
+RUN pip install pyinstaller==4.10
+
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install -r requirements.txt
+
+COPY . /app
+RUN pyinstaller --onefile --windowed radixnode.spec
+
+RUN DISABLE_VERSION_CHECK=true /app/dist/radixnode version
+
+FROM scratch AS export-stage
+COPY --from=BUILD /app/dist /

--- a/node-runner-cli/Makefile
+++ b/node-runner-cli/Makefile
@@ -3,11 +3,14 @@ install:
 	$(shell chmod +x add-version.sh)
 	$(shell ./add-version.sh)
 	pip install pipenv
-	pipenv lock -r > requirements.txt
+	pipenv requirements > requirements.txt
 
 .PHONY: output
 output-ubuntu-focal: install
 	DOCKER_BUILDKIT=1 docker build --output type=local,dest=out/ubuntu/focal --progress plain -f Dockerfile.ubuntufocal  .
+
+output-ubuntu-jammy: install
+	DOCKER_BUILDKIT=1 docker build --output type=local,dest=out/ubuntu/jammy --progress plain -f Dockerfile.ubuntujammy  .
 
 .PHONY: local
 local: install


### PR DESCRIPTION
## node-runner: add support for 22.04 + build instructions

## Description

1. There are no instructions on how to build this repo. Since release only targets amd64 users who are running aarch64 will not know how to install this.  Added build instructions.

4. Added build support for Ubuntu 22.04 ( Jammy ).